### PR TITLE
Mobile search is cleaned up a bit

### DIFF
--- a/server/public/css/components/_buttons.scss
+++ b/server/public/css/components/_buttons.scss
@@ -40,6 +40,9 @@
 	padding: 0;
 	max-width: 100%;
 	min-width: 2.3em;
+	@include respond(mobile) {
+		min-width: initial;
+	}
 	button {
 		width: 100%;
 		height: 2em;
@@ -48,21 +51,7 @@
 		text-align: center;
 		span {
 			color: $white;
-		}
-	}
-}
-
-@media (max-width: 320px) {
-	#search {
-		button {
-			span {
-				left: -0.4em;
-			}
-		}
-	}
-	#yourLocation {
-		button {
-			span {
+			@include respond(mobile) {
 				left: -0.4em;
 			}
 		}

--- a/server/public/css/components/_forms.scss
+++ b/server/public/css/components/_forms.scss
@@ -101,7 +101,7 @@
 #search-service-and-loc {
 	height: 100%;
 	@include respond(mobile) {
-		height: inherit;
+		height: initial;
 		box-shadow: 0px 0px 5px 0px black;
 	}
 }

--- a/server/public/css/components/site-nav/_accordiangeneral.scss
+++ b/server/public/css/components/site-nav/_accordiangeneral.scss
@@ -14,26 +14,18 @@
 	text-align: center;
 	@include respond(mobile) {
        height: 11.5em;
-       h2 {
-               margin: 0.3em 0em;
-       }
-   }
+       height: initial;
+    }
 	h2 {
 		margin: 0.7em 0em;
 		text-align: center;
 		color: $white;
+		@include respond(mobile) {
+			margin: 0.3em 0em;
+		}
 	}
 	#back {
 		width: 2.6em;
-	}
-}
-
-@media (max-width: 768px) {
-	.services-and-categories {
-		height: 11.5em;
-		h2 {
-			margin: 0.3em 0em;
-		}
 	}
 }
 

--- a/server/public/css/components/site-nav/_home.scss
+++ b/server/public/css/components/site-nav/_home.scss
@@ -6,7 +6,6 @@
 		width: 100%;
 		padding: 0;
 		margin: 0;
-		margin-top: 2em;
 	}
 }
 

--- a/server/public/partials/root.address-found.html
+++ b/server/public/partials/root.address-found.html
@@ -8,7 +8,7 @@
         <div class="col-xs-12 search-box" id="search-service-and-loc">
             <div class="servicestypeahead row">
                 <div class="col-xs-2 col-md-2">
-                    <a class="col-xs-1 col-md-1" ng-click="searchAgain()">
+                    <a ng-click="searchAgain()">
                         <img id="backhome" src="../img/icons/backhome.png" alt="back">
                     </a> 
                 </div>
@@ -19,7 +19,7 @@
                         <input type="text" placeholder="{{ placeholder }}" ng-model="address" class="form-control"/>
                     </div>
 
-                    <div class="col-xs-2 col-md-1">
+                    <div class="col-xs-1 col-md-1">
                         <button type="submit" ng-click="search()">
                             <span class="glyphicon glyphicon-search"></span>
                         </button>
@@ -38,7 +38,7 @@
             </div>
             <div class="row">
                 <h3 id="locations" class="col-md-offset-2 col-md-7">Services near {{ address }}</h3>
-                <a class="change-address col-md-3" ng-click="changeAddress()">
+                <a class="change-address" ng-click="changeAddress()">
                     <p>Reset location</p>
                 </a>
             </div>

--- a/server/public/partials/typeahead-search.html
+++ b/server/public/partials/typeahead-search.html
@@ -11,7 +11,7 @@
 	    <input type="text" placeholder="{{ placeholder }}" ng-model="selected" typeahead="searchitem.title for searchitem in typeaheadSearchList{{ additions }}" class="form-control"/>
 	</div>
 
-	<div class="col-xs-2 col-md-1">
+	<div class="col-xs-1 col-md-1">
 	    <button type="submit">
 	        <span class="glyphicon glyphicon-search"></span>
 	    </button>


### PR DESCRIPTION
### Removed some bootstrap block styles on anchors and fixed various padding and margins.

NB: if you apply a class like "col-md-1" to an anchor it'll no longer display inline-block and will occupy vertical space as well as much horizontal space as it can. Grid system classes should be used only with document divisions. 